### PR TITLE
feat: model tracking per message

### DIFF
--- a/apps/backend/src/http/any-api-streams-000workspaceId-000agentId-000secret/index.ts
+++ b/apps/backend/src/http/any-api-streams-000workspaceId-000agentId-000secret/index.ts
@@ -820,12 +820,14 @@ async function logConversation(
       assistantContent.push({ type: "text", text: finalResponseText });
     }
 
-    // Create assistant message with token usage (same as test endpoint)
+    // Create assistant message with token usage, modelName, and provider (same as test endpoint)
     const assistantMessage: UIMessage = {
       role: "assistant",
       content:
         assistantContent.length > 0 ? assistantContent : finalResponseText,
       ...(tokenUsage && { tokenUsage }),
+      modelName: finalModelName,
+      provider: "google",
     };
 
     // DIAGNOSTIC: Log assistant message structure
@@ -885,9 +887,7 @@ async function logConversation(
       agentId,
       conversationId,
       validMessages,
-      tokenUsage,
-      finalModelName,
-      "google" // provider
+      tokenUsage
     ).catch((error) => {
       // Log error but don't fail the request
       console.error("[Stream Handler] Error logging conversation:", {

--- a/apps/backend/src/http/any-api-workspaces-catchall/routes/get-agent-conversation.ts
+++ b/apps/backend/src/http/any-api-workspaces-catchall/routes/get-agent-conversation.ts
@@ -61,12 +61,6 @@ import { asyncHandler, requireAuth, requirePermission } from "../middleware";
  *                 tokenUsage:
  *                   type: object
  *                   nullable: true
- *                 modelName:
- *                   type: string
- *                   nullable: true
- *                 provider:
- *                   type: string
- *                   nullable: true
  *                 startedAt:
  *                   type: string
  *                   format: date-time
@@ -131,8 +125,6 @@ export const registerGetAgentConversation = (app: express.Application) => {
         toolCalls: conversation.toolCalls || [],
         toolResults: conversation.toolResults || [],
         tokenUsage: conversation.tokenUsage || null,
-        modelName: conversation.modelName || null,
-        provider: conversation.provider || null,
         startedAt: conversation.startedAt,
         lastMessageAt: conversation.lastMessageAt,
       });

--- a/apps/backend/src/http/any-api-workspaces-catchall/routes/get-agent-conversations.ts
+++ b/apps/backend/src/http/any-api-workspaces-catchall/routes/get-agent-conversations.ts
@@ -69,12 +69,6 @@ import { asyncHandler, requireAuth, requirePermission } from "../middleware";
  *                       tokenUsage:
  *                         type: object
  *                         nullable: true
- *                       modelName:
- *                         type: string
- *                         nullable: true
- *                       provider:
- *                         type: string
- *                         nullable: true
  *                 nextCursor:
  *                   type: string
  *                   nullable: true
@@ -159,8 +153,6 @@ export const registerGetAgentConversations = (app: express.Application) => {
             lastMessageAt: c.lastMessageAt,
             messageCount: Array.isArray(c.messages) ? c.messages.length : 0,
             tokenUsage: c.tokenUsage || null,
-            modelName: c.modelName || null,
-            provider: c.provider || null,
           };
         });
 

--- a/apps/backend/src/http/any-api-workspaces-catchall/routes/post-test-agent.ts
+++ b/apps/backend/src/http/any-api-workspaces-catchall/routes/post-test-agent.ts
@@ -771,11 +771,13 @@ export const registerPostTestAgent = (app: express.Application) => {
         assistantContent.push({ type: "text", text: responseText });
       }
 
-      // Create assistant message with token usage
+      // Create assistant message with token usage, modelName, and provider
       const assistantMessage: UIMessage = {
         role: "assistant",
         content: assistantContent.length > 0 ? assistantContent : responseText,
         ...(tokenUsage && { tokenUsage }),
+        modelName: finalModelName,
+        provider: "google",
       };
 
       // Combine user messages and assistant message for logging
@@ -808,9 +810,7 @@ export const registerPostTestAgent = (app: express.Application) => {
           agentId,
           conversationId,
           validMessages,
-          tokenUsage,
-          finalModelName,
-          "google" // provider
+          tokenUsage
         );
       } catch (error) {
         // Log error but don't fail the request

--- a/apps/backend/src/http/post-api-webhook-000workspaceId-000agentId-000key/index.ts
+++ b/apps/backend/src/http/post-api-webhook-000workspaceId-000agentId-000key/index.ts
@@ -619,7 +619,7 @@ export const handler = adaptHttpHandler(
         }
       );
 
-      // Create assistant message
+      // Create assistant message with modelName and provider
       // Ensure content is always an array if we have tool calls/results, even if text is empty
       const assistantMessage: UIMessage = {
         role: "assistant",
@@ -627,6 +627,8 @@ export const handler = adaptHttpHandler(
           assistantContent.length > 0
             ? assistantContent
             : responseContent || "",
+        modelName: finalModelName,
+        provider: "google",
       };
 
       // DIAGNOSTIC: Log final assistant message structure
@@ -687,8 +689,6 @@ export const handler = adaptHttpHandler(
             conversationType: "webhook",
             messages: messagesToLog,
             tokenUsage,
-            modelName: finalModelName,
-            provider: "google",
             usesByok,
           });
         } else {

--- a/apps/backend/src/http/post-api-workspaces-000workspaceId-agents-000agentId-test/utils/types.ts
+++ b/apps/backend/src/http/post-api-workspaces-000workspaceId-agents-000agentId-test/utils/types.ts
@@ -35,6 +35,8 @@ export type UIMessage =
         reasoningTokens?: number;
         cachedPromptTokens?: number;
       };
+      modelName?: string; // AI model name used for this message (e.g., "gemini-2.0-flash-exp")
+      provider?: string; // AI provider name used for this message (e.g., "google")
     }
   | {
       role: "system";

--- a/apps/backend/src/tables/schema.ts
+++ b/apps/backend/src/tables/schema.ts
@@ -188,8 +188,8 @@ export const tableSchemas = {
         cachedPromptTokens: z.number().optional(), // Cached prompt tokens (if prompt caching is used)
       })
       .optional(), // aggregated token usage across all API calls
-    modelName: z.string().optional(), // name of the AI model used (e.g., "gemini-2.5-flash-preview-05-20")
-    provider: z.string().optional(), // AI provider name (e.g., "google")
+    modelName: z.string().optional(), // @deprecated - Use per-message modelName instead. Kept for backward compatibility.
+    provider: z.string().optional(), // @deprecated - Use per-message provider instead. Kept for backward compatibility.
     usesByok: z.boolean().optional(), // whether this conversation used BYOK (Bring Your Own Key)
     costUsd: z.number().int().optional(), // cost in USD in millionths
     startedAt: z.string().datetime(), // when conversation started

--- a/apps/frontend/src/components/AgentChat.tsx
+++ b/apps/frontend/src/components/AgentChat.tsx
@@ -606,6 +606,20 @@ export const AgentChat: FC<AgentChatProps> = ({
                     })
                   : null;
 
+              // Check if message has modelName and provider (for assistant messages)
+              const modelName =
+                message.role === "assistant" &&
+                "modelName" in message &&
+                typeof message.modelName === "string"
+                  ? message.modelName
+                  : null;
+              const provider =
+                message.role === "assistant" &&
+                "provider" in message &&
+                typeof message.provider === "string"
+                  ? message.provider
+                  : null;
+
               const formatTokenUsage = (usage: {
                 promptTokens?: number;
                 completionTokens?: number;
@@ -664,11 +678,18 @@ export const AgentChat: FC<AgentChatProps> = ({
                               <div className="text-xs font-medium opacity-80">
                                 {getRoleLabel()}
                               </div>
-                              {tokenUsage && (
-                                <div className="text-xs font-mono opacity-70 bg-black bg-opacity-10 px-2 py-1 rounded">
-                                  {formatTokenUsage(tokenUsage)}
-                                </div>
-                              )}
+                              <div className="flex items-center gap-2">
+                                {modelName && provider && (
+                                  <div className="text-xs font-medium opacity-70 bg-blue-100 text-blue-800 px-2 py-1 rounded">
+                                    {provider}/{modelName}
+                                  </div>
+                                )}
+                                {tokenUsage && (
+                                  <div className="text-xs font-mono opacity-70 bg-black bg-opacity-10 px-2 py-1 rounded">
+                                    {formatTokenUsage(tokenUsage)}
+                                  </div>
+                                )}
+                              </div>
                             </div>
                             {renderPart(part, partIndex)}
                           </div>
@@ -686,11 +707,18 @@ export const AgentChat: FC<AgentChatProps> = ({
                         <div className="text-sm font-bold opacity-90">
                           {getRoleLabel()}
                         </div>
-                        {tokenUsage && (
-                          <div className="text-xs font-mono opacity-70 bg-black bg-opacity-10 px-2 py-1 rounded">
-                            {formatTokenUsage(tokenUsage)}
-                          </div>
-                        )}
+                        <div className="flex items-center gap-2">
+                          {modelName && provider && (
+                            <div className="text-xs font-medium opacity-70 bg-blue-100 text-blue-800 px-2 py-1 rounded">
+                              {provider}/{modelName}
+                            </div>
+                          )}
+                          {tokenUsage && (
+                            <div className="text-xs font-mono opacity-70 bg-black bg-opacity-10 px-2 py-1 rounded">
+                              {formatTokenUsage(tokenUsage)}
+                            </div>
+                          )}
+                        </div>
                       </div>
                       <div className="text-base text-neutral-600 italic font-medium">
                         (Empty message)

--- a/apps/frontend/src/components/ConversationDetailModal.tsx
+++ b/apps/frontend/src/components/ConversationDetailModal.tsx
@@ -158,24 +158,6 @@ export const ConversationDetailModal: FC<ConversationDetailModalProps> = ({
                 {formatDate(conversationDetail.lastMessageAt)}
               </div>
             </div>
-            {conversationDetail.modelName && (
-              <div>
-                <div className="font-medium text-neutral-700 mb-1">Model</div>
-                <div className="text-xs bg-white px-2 py-1 border border-neutral-300 rounded inline-block text-neutral-900">
-                  {conversationDetail.modelName}
-                </div>
-              </div>
-            )}
-            {conversationDetail.provider && (
-              <div>
-                <div className="font-medium text-neutral-700 mb-1">
-                  Provider
-                </div>
-                <div className="text-xs bg-white px-2 py-1 border border-neutral-300 rounded inline-block text-neutral-900">
-                  {conversationDetail.provider}
-                </div>
-              </div>
-            )}
             {conversationDetail.tokenUsage && (
               <div className="col-span-2">
                 <div className="font-medium text-neutral-700 mb-1">
@@ -256,6 +238,18 @@ export const ConversationDetailModal: FC<ConversationDetailModalProps> = ({
                           "tokenUsage" in message
                             ? formatTokenUsage(message.tokenUsage)
                             : null;
+                        const modelName =
+                          role === "assistant" &&
+                          "modelName" in message &&
+                          typeof message.modelName === "string"
+                            ? message.modelName
+                            : null;
+                        const provider =
+                          role === "assistant" &&
+                          "provider" in message &&
+                          typeof message.provider === "string"
+                            ? message.provider
+                            : null;
                         return (
                           <div
                             key={index}
@@ -271,11 +265,18 @@ export const ConversationDetailModal: FC<ConversationDetailModalProps> = ({
                               <div className="text-xs font-medium opacity-80">
                                 {role}
                               </div>
-                              {tokenUsage && (
-                                <div className="text-xs font-mono opacity-70 bg-black bg-opacity-10 px-2 py-1 rounded">
-                                  {tokenUsage}
-                                </div>
-                              )}
+                              <div className="flex items-center gap-2">
+                                {modelName && provider && (
+                                  <div className="text-xs font-medium opacity-70 bg-blue-100 text-blue-800 px-2 py-1 rounded">
+                                    {provider}/{modelName}
+                                  </div>
+                                )}
+                                {tokenUsage && (
+                                  <div className="text-xs font-mono opacity-70 bg-black bg-opacity-10 px-2 py-1 rounded">
+                                    {tokenUsage}
+                                  </div>
+                                )}
+                              </div>
                             </div>
                             <div className="text-sm whitespace-pre-wrap">
                               {content}

--- a/apps/frontend/src/utils/api.ts
+++ b/apps/frontend/src/utils/api.ts
@@ -742,8 +742,6 @@ export interface Conversation {
     completionTokens: number;
     totalTokens: number;
   } | null;
-  modelName: string | null;
-  provider: string | null;
 }
 
 export interface ConversationDetail extends Conversation {


### PR DESCRIPTION
Currently, conversations store modelName and provider once at the conversation level. However, different messages in the same conversation can use different models or providers. This PR implements per-message tracking of model and provider information and displays it in the UI.