### PR TITLE
feat: agent tools config

### DIFF
--- a/apps/backend/src/http/any-api-workspaces-catchall/routes/get-workspace-agent.ts
+++ b/apps/backend/src/http/any-api-workspaces-catchall/routes/get-workspace-agent.ts
@@ -109,6 +109,8 @@ export const registerGetWorkspaceAgent = (app: express.Application) => {
           delegatableAgentIds: agent.delegatableAgentIds ?? [],
           enabledMcpServerIds: agent.enabledMcpServerIds ?? [],
           enableMemorySearch: agent.enableMemorySearch ?? false,
+          enableSearchDocuments: agent.enableSearchDocuments ?? false,
+          enableSendEmail: agent.enableSendEmail ?? false,
           clientTools: agent.clientTools ?? [],
           spendingLimits: agent.spendingLimits ?? [],
           temperature: agent.temperature ?? null,

--- a/apps/backend/src/http/any-api-workspaces-catchall/routes/get-workspace-agents.ts
+++ b/apps/backend/src/http/any-api-workspaces-catchall/routes/get-workspace-agents.ts
@@ -69,6 +69,8 @@ export const registerGetWorkspaceAgents = (app: express.Application) => {
           delegatableAgentIds: agent.delegatableAgentIds ?? [],
           enabledMcpServerIds: agent.enabledMcpServerIds ?? [],
           enableMemorySearch: agent.enableMemorySearch ?? false,
+          enableSearchDocuments: agent.enableSearchDocuments ?? false,
+          enableSendEmail: agent.enableSendEmail ?? false,
           clientTools: agent.clientTools ?? [],
           spendingLimits: agent.spendingLimits ?? [],
           provider: agent.provider,

--- a/apps/backend/src/http/any-api-workspaces-catchall/routes/post-generate-prompt.ts
+++ b/apps/backend/src/http/any-api-workspaces-catchall/routes/post-generate-prompt.ts
@@ -111,6 +111,8 @@ export const registerPostGeneratePrompt = (app: express.Application) => {
           delegatableAgentIds?: string[];
           enabledMcpServerIds?: string[];
           enableMemorySearch?: boolean;
+          enableSearchDocuments?: boolean;
+          enableSendEmail?: boolean;
         } | null = null;
 
         if (agentId && typeof agentId === "string") {
@@ -128,6 +130,8 @@ export const registerPostGeneratePrompt = (app: express.Application) => {
             delegatableAgentIds: agentRecord.delegatableAgentIds,
             enabledMcpServerIds: agentRecord.enabledMcpServerIds,
             enableMemorySearch: agentRecord.enableMemorySearch,
+            enableSearchDocuments: agentRecord.enableSearchDocuments,
+            enableSendEmail: agentRecord.enableSendEmail,
           };
         }
 
@@ -145,9 +149,14 @@ export const registerPostGeneratePrompt = (app: express.Application) => {
 
         // Server-side tools
         toolsInfo.push("## Server-Side Tools (Built-in)");
-        toolsInfo.push(
-          "- **search_documents**: Always available. Search workspace documents using semantic vector search."
-        );
+        
+        // Document search tool (conditional)
+        if (agent?.enableSearchDocuments === true) {
+          availableTools.push("search_documents");
+          toolsInfo.push(
+            "- **search_documents**: Available. Search workspace documents using semantic vector search."
+          );
+        }
 
         // Memory search tool (conditional)
         if (agent?.enableMemorySearch === true) {
@@ -164,7 +173,8 @@ export const registerPostGeneratePrompt = (app: express.Application) => {
           );
         }
 
-        if (hasEmailConnection) {
+        // Email tool (conditional - requires both agent flag and workspace email connection)
+        if (agent?.enableSendEmail === true && hasEmailConnection) {
           availableTools.push("send_email");
           toolsInfo.push(
             "- **send_email**: Available. Send emails using the workspace email connection."

--- a/apps/backend/src/http/any-api-workspaces-catchall/routes/put-workspace-agent.ts
+++ b/apps/backend/src/http/any-api-workspaces-catchall/routes/put-workspace-agent.ts
@@ -101,6 +101,8 @@ export const registerPutWorkspaceAgent = (app: express.Application) => {
           delegatableAgentIds,
           enabledMcpServerIds,
           enableMemorySearch,
+          enableSearchDocuments,
+          enableSendEmail,
           clientTools,
           temperature,
           topP,
@@ -396,6 +398,14 @@ export const registerPutWorkspaceAgent = (app: express.Application) => {
             enableMemorySearch !== undefined
               ? enableMemorySearch
               : agent.enableMemorySearch,
+          enableSearchDocuments:
+            enableSearchDocuments !== undefined
+              ? enableSearchDocuments
+              : agent.enableSearchDocuments,
+          enableSendEmail:
+            enableSendEmail !== undefined
+              ? enableSendEmail
+              : agent.enableSendEmail,
           clientTools:
             clientTools !== undefined ? clientTools : agent.clientTools,
           spendingLimits:
@@ -456,6 +466,8 @@ export const registerPutWorkspaceAgent = (app: express.Application) => {
           delegatableAgentIds: updated.delegatableAgentIds ?? [],
           enabledMcpServerIds: updated.enabledMcpServerIds ?? [],
           enableMemorySearch: updated.enableMemorySearch ?? false,
+          enableSearchDocuments: updated.enableSearchDocuments ?? false,
+          enableSendEmail: updated.enableSendEmail ?? false,
           clientTools: updated.clientTools ?? [],
           spendingLimits: updated.spendingLimits ?? [],
           temperature: updated.temperature ?? null,

--- a/apps/backend/src/openapi/schemas.ts
+++ b/apps/backend/src/openapi/schemas.ts
@@ -166,6 +166,14 @@ export const openApiSchemas = {
         type: "boolean",
         description: "Enable the memory search tool for this agent",
       },
+      enableSearchDocuments: {
+        type: "boolean",
+        description: "Enable the document search tool for this agent",
+      },
+      enableSendEmail: {
+        type: "boolean",
+        description: "Enable the email sending tool for this agent (requires workspace email connection)",
+      },
       createdAt: {
         type: "string",
         format: "date-time",
@@ -252,6 +260,14 @@ export const openApiSchemas = {
         type: "boolean",
         description: "Enable the memory search tool for this agent",
       },
+      enableSearchDocuments: {
+        type: "boolean",
+        description: "Enable the document search tool for this agent",
+      },
+      enableSendEmail: {
+        type: "boolean",
+        description: "Enable the email sending tool for this agent (requires workspace email connection)",
+      },
     },
   },
   UpdateAgentRequest: {
@@ -294,6 +310,14 @@ export const openApiSchemas = {
       enableMemorySearch: {
         type: "boolean",
         description: "Enable the memory search tool for this agent",
+      },
+      enableSearchDocuments: {
+        type: "boolean",
+        description: "Enable the document search tool for this agent",
+      },
+      enableSendEmail: {
+        type: "boolean",
+        description: "Enable the email sending tool for this agent (requires workspace email connection)",
       },
     },
   },

--- a/apps/backend/src/tables/schema.ts
+++ b/apps/backend/src/tables/schema.ts
@@ -89,6 +89,8 @@ export const tableSchemas = {
     delegatableAgentIds: z.array(z.string()).optional(), // list of agent IDs this agent can delegate to
     enabledMcpServerIds: z.array(z.string()).optional(), // list of MCP server IDs enabled for this agent
     enableMemorySearch: z.boolean().optional(), // enable memory search tool for this agent (default: false)
+    enableSearchDocuments: z.boolean().optional(), // enable document search tool for this agent (default: false)
+    enableSendEmail: z.boolean().optional(), // enable email sending tool for this agent (default: false, requires workspace email connection)
     spendingLimits: z
       .array(
         z.object({

--- a/apps/frontend/src/components/PromptGeneratorDialog.tsx
+++ b/apps/frontend/src/components/PromptGeneratorDialog.tsx
@@ -58,14 +58,14 @@ export const PromptGeneratorDialog: FC<PromptGeneratorDialogProps> = ({
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50 p-4">
-      <div className="max-h-[90vh] w-full max-w-3xl overflow-y-auto rounded-2xl border-2 border-neutral-300 bg-white p-8 shadow-dramatic">
+      <div className="max-h-[90vh] w-full max-w-3xl overflow-y-auto rounded-2xl border-2 border-neutral-300 bg-white p-8 shadow-dramatic dark:border-neutral-700 dark:bg-neutral-900">
         <div className="mb-6 flex items-center justify-between">
-          <h2 className="text-3xl font-semibold text-neutral-900">
+          <h2 className="text-3xl font-semibold text-neutral-900 dark:text-neutral-50">
             Generate System Prompt
           </h2>
           <button
             onClick={handleClose}
-            className="rounded-xl border border-neutral-300 bg-white px-6 py-2 font-medium text-neutral-700 transition-colors hover:bg-neutral-50"
+            className="rounded-xl border border-neutral-300 bg-white px-6 py-2 font-medium text-neutral-700 transition-colors hover:bg-neutral-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-50 dark:hover:bg-neutral-800"
           >
             Close
           </button>
@@ -75,7 +75,7 @@ export const PromptGeneratorDialog: FC<PromptGeneratorDialogProps> = ({
           <div>
             <label
               htmlFor="goal"
-              className="mb-2 block text-sm font-medium text-neutral-700"
+              className="mb-2 block text-sm font-medium text-neutral-700 dark:text-neutral-300"
             >
               Describe your agent&apos;s goal
             </label>
@@ -84,10 +84,10 @@ export const PromptGeneratorDialog: FC<PromptGeneratorDialogProps> = ({
               value={goal}
               onChange={(e) => setGoal(e.target.value)}
               placeholder="e.g., I want an agent that helps customers with technical support questions, provides clear explanations, and escalates complex issues to the engineering team."
-              className="w-full rounded-xl border border-neutral-300 bg-white px-4 py-2.5 text-neutral-900 transition-colors focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500"
+              className="w-full rounded-xl border border-neutral-300 bg-white px-4 py-2.5 text-neutral-900 transition-colors focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-50 dark:focus:ring-primary-400"
               rows={4}
             />
-            <p className="mt-1.5 text-xs text-neutral-600">
+            <p className="mt-1.5 text-xs text-neutral-600 dark:text-neutral-300">
               Provide a description of what you want your agent to do. The more
               specific you are, the better the generated prompt will be.
             </p>
@@ -106,25 +106,25 @@ export const PromptGeneratorDialog: FC<PromptGeneratorDialogProps> = ({
               type="button"
               onClick={handleClose}
               disabled={generatePrompt.isPending}
-              className="flex-1 rounded-xl border border-neutral-300 bg-white px-4 py-2.5 font-medium text-neutral-700 transition-colors hover:bg-neutral-50 disabled:cursor-not-allowed disabled:opacity-50"
+              className="flex-1 rounded-xl border border-neutral-300 bg-white px-4 py-2.5 font-medium text-neutral-700 transition-colors hover:bg-neutral-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-50 dark:hover:bg-neutral-800"
             >
               Cancel
             </button>
           </div>
 
           {generatePrompt.isPending && (
-            <div className="rounded-lg border border-neutral-200 bg-neutral-50 p-6">
+            <div className="rounded-lg border border-neutral-200 bg-neutral-50 p-6 dark:border-neutral-700 dark:bg-neutral-800">
               <LoadingScreen compact message="Generating your prompt..." />
             </div>
           )}
 
           {generatedPrompt && !generatePrompt.isPending && (
             <div className="space-y-4">
-              <div className="rounded-lg border border-green-200 bg-green-50 p-4">
-                <p className="mb-2 text-sm font-semibold text-green-800">
+              <div className="rounded-lg border border-green-200 bg-green-50 p-4 dark:border-green-800 dark:bg-green-950">
+                <p className="mb-2 text-sm font-semibold text-green-800 dark:text-green-200">
                   ✓ Prompt Generated
                 </p>
-                <p className="text-xs text-green-900">
+                <p className="text-xs text-green-900 dark:text-green-100">
                   Review the generated prompt below. You can use it as-is or
                   modify it before applying.
                 </p>
@@ -133,7 +133,7 @@ export const PromptGeneratorDialog: FC<PromptGeneratorDialogProps> = ({
               <div>
                 <label
                   htmlFor="generatedPrompt"
-                  className="mb-2 block text-sm font-medium text-neutral-700"
+                  className="mb-2 block text-sm font-medium text-neutral-700 dark:text-neutral-300"
                 >
                   Generated System Prompt
                 </label>
@@ -141,10 +141,10 @@ export const PromptGeneratorDialog: FC<PromptGeneratorDialogProps> = ({
                   id="generatedPrompt"
                   value={generatedPrompt}
                   onChange={(e) => setGeneratedPrompt(e.target.value)}
-                  className="w-full rounded-xl border border-neutral-300 bg-white px-4 py-2.5 font-mono text-sm text-neutral-900 transition-colors focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500"
+                  className="w-full rounded-xl border border-neutral-300 bg-white px-4 py-2.5 font-mono text-sm text-neutral-900 transition-colors focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-50 dark:focus:ring-primary-400"
                   rows={12}
                 />
-                <p className="mt-1.5 text-xs text-neutral-600">
+                <p className="mt-1.5 text-xs text-neutral-600 dark:text-neutral-300">
                   You can edit the generated prompt before using it.
                 </p>
               </div>
@@ -160,7 +160,7 @@ export const PromptGeneratorDialog: FC<PromptGeneratorDialogProps> = ({
                 <button
                   type="button"
                   onClick={handleClose}
-                  className="flex-1 rounded-xl border border-neutral-300 bg-white px-4 py-2.5 font-medium text-neutral-700 transition-colors hover:bg-neutral-50"
+                  className="flex-1 rounded-xl border border-neutral-300 bg-white px-4 py-2.5 font-medium text-neutral-700 transition-colors hover:bg-neutral-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-50 dark:hover:bg-neutral-800"
                 >
                   Cancel
                 </button>
@@ -169,11 +169,11 @@ export const PromptGeneratorDialog: FC<PromptGeneratorDialogProps> = ({
           )}
 
           {generatePrompt.isError && !generatePrompt.isPending && (
-            <div className="rounded-lg border border-red-200 bg-red-50 p-4">
-              <p className="mb-1 text-sm font-semibold text-red-800">
+            <div className="rounded-lg border border-red-200 bg-red-50 p-4 dark:border-red-800 dark:bg-red-950">
+              <p className="mb-1 text-sm font-semibold text-red-800 dark:text-red-200">
                 Error generating prompt
               </p>
-              <p className="text-xs text-red-900">
+              <p className="text-xs text-red-900 dark:text-red-100">
                 {generatePrompt.error instanceof Error
                   ? generatePrompt.error.message
                   : "An error occurred while generating the prompt. Please try again."}

--- a/apps/frontend/src/components/ToolsHelpDialog.tsx
+++ b/apps/frontend/src/components/ToolsHelpDialog.tsx
@@ -30,6 +30,8 @@ export const ToolsHelpDialog: FC<ToolsHelpDialogProps> = ({
   const hasDelegation =
     agent?.delegatableAgentIds && agent.delegatableAgentIds.length > 0;
   const hasMemorySearch = agent?.enableMemorySearch === true;
+  const hasSearchDocuments = agent?.enableSearchDocuments === true;
+  const hasSendEmail = agent?.enableSendEmail === true && hasEmailConnection;
   const enabledMcpServerIds = agent?.enabledMcpServerIds || [];
   const enabledMcpServers =
     mcpServersData?.servers.filter((server) =>
@@ -41,8 +43,10 @@ export const ToolsHelpDialog: FC<ToolsHelpDialogProps> = ({
       name: "search_documents",
       description:
         "Search workspace documents using semantic vector search. Returns the most relevant document snippets based on the query.",
-      alwaysAvailable: true,
-      condition: null,
+      alwaysAvailable: false,
+      condition: hasSearchDocuments
+        ? "Available (document search enabled)"
+        : "Not available (document search not enabled)",
       parameters: [
         {
           name: "query",
@@ -128,9 +132,13 @@ export const ToolsHelpDialog: FC<ToolsHelpDialogProps> = ({
       description:
         "Send an email using the workspace email connection (Gmail, Outlook, or SMTP).",
       alwaysAvailable: false,
-      condition: hasEmailConnection
-        ? "Available (email connection configured)"
-        : "Not available (no email connection configured)",
+      condition: hasSendEmail
+        ? "Available (email tool enabled and email connection configured)"
+        : agent?.enableSendEmail === true && !hasEmailConnection
+          ? "Not available (email tool enabled but no email connection configured)"
+          : !agent?.enableSendEmail
+            ? "Not available (email tool not enabled)"
+            : "Not available (email tool not enabled and no email connection configured)",
       parameters: [
         {
           name: "to",

--- a/apps/frontend/src/hooks/useAgents.ts
+++ b/apps/frontend/src/hooks/useAgents.ts
@@ -74,10 +74,20 @@ export function useUpdateAgent(workspaceId: string, agentId: string) {
         ["workspaces", workspaceId, "agents", agentId],
         data
       );
-      // Invalidate the list query to ensure it reflects the update
-      // We don't invalidate the specific agent query since we've already set it with fresh data
+      // Invalidate only the list query (not the specific agent query) to ensure it reflects the update
+      // We use a predicate to only match the exact list query key, not the specific agent query
       queryClient.invalidateQueries({
-        queryKey: ["workspaces", workspaceId, "agents"],
+        predicate: (query) => {
+          const queryKey = query.queryKey;
+          // Only invalidate the exact list query: ["workspaces", workspaceId, "agents"]
+          return (
+            Array.isArray(queryKey) &&
+            queryKey.length === 3 &&
+            queryKey[0] === "workspaces" &&
+            queryKey[1] === workspaceId &&
+            queryKey[2] === "agents"
+          );
+        },
       });
       toast.success("Agent updated successfully");
     },

--- a/apps/frontend/src/utils/api.ts
+++ b/apps/frontend/src/utils/api.ts
@@ -79,6 +79,8 @@ export interface Agent {
   delegatableAgentIds?: string[];
   enabledMcpServerIds?: string[];
   enableMemorySearch?: boolean;
+  enableSearchDocuments?: boolean;
+  enableSendEmail?: boolean;
   clientTools?: ClientTool[];
   spendingLimits?: SpendingLimit[];
   temperature?: number;
@@ -108,6 +110,8 @@ export interface UpdateAgentInput {
   delegatableAgentIds?: string[];
   enabledMcpServerIds?: string[];
   enableMemorySearch?: boolean;
+  enableSearchDocuments?: boolean;
+  enableSendEmail?: boolean;
   clientTools?: ClientTool[];
   spendingLimits?: SpendingLimit[];
   temperature?: number | null;


### PR DESCRIPTION
Make all agent tools opt-in by default. Currently, search_documents is always available and send_email is based on workspace email connection. We'll add configuration flags to the agent schema and update all tool setup locations to respect these flags.