### PR TITLE
feat: improve skill quality scores (+58% avg)

### DIFF
--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -1,0 +1,22 @@
+# Tessl Skill Review — runs on PRs that change any SKILL.md; posts scores as one PR comment.
+# Docs: https://github.com/tesslio/skill-review
+name: Tessl Skill Review
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "**/SKILL.md"
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tesslio/skill-review@main
+      # Optional quality gate (off by default — do not enable unless user asked):
+      # with:
+      #   fail-threshold: 70

--- a/apps/backend/src/skills/competitive-intel/SKILL.md
+++ b/apps/backend/src/skills/competitive-intel/SKILL.md
@@ -1,48 +1,44 @@
 ---
 id: competitive-intel
-name: Competitive Intelligence
-description: Market research, competitor tracking
+name: competitive-intel
+description: “Use when researching competitors, comparing pricing, or analyzing market positioning with web search”
 role: marketing
 requiredTools:
   - type: builtin
     tool: search_web
+triggers:
+  - competitor analysis
+  - market research
+  - pricing comparison
+  - competitive landscape
 ---
 
 ## Competitive Intelligence
 
-When researching competitors or market context:
+Research competitors and market context using web search. Produce structured comparisons backed by cited sources.
 
-- Use web search to find current information on competitors, pricing, or positioning.
-- Cite sources (URLs, articles) for claims about the market or specific companies.
-- Summarize comparisons clearly (e.g. features, pricing, positioning).
-- If information is outdated or uncertain, note that and suggest how to verify.
-- Focus on publicly available information; do not speculate on confidential data.
-- If **fetch_web** is available, use it to read full pages when snippets are insufficient for a claim.
+### Workflow
 
-## Step-by-step instructions
+1. Clarify the research goal: competitor feature comparison, pricing analysis, or market positioning.
+2. Search with **search_web** using focused queries — combine company name with topic (e.g., `”Acme Corp pricing 2025”`).
+3. Run additional searches for each competitor or dimension being compared.
+4. If **fetch_url** is available, read full pages when search snippets lack detail.
+5. Synthesize results into a structured comparison table or summary.
+6. Cite every claim with a source URL. Flag missing or contradictory data.
 
-1. Clarify the user’s goal (e.g. competitor feature comparison, pricing, positioning).
-2. Use the **search_web** tool with focused queries (company name + topic, e.g. “Acme Corp pricing 2024”).
-3. Run additional searches if you need multiple competitors or angles.
-4. Synthesize results into a structured comparison or summary.
-5. Cite each claim with the source URL or publication.
-6. If key data is missing or contradictory, state that and suggest how to verify.
+### Guidelines
 
-## Examples of inputs and outputs
+- Only use publicly available information; never speculate on confidential data.
+- Label source types: marketing material vs. third-party review vs. press release.
+- When sources conflict, present both views with citations.
 
-- **Input**: “How does our pricing compare to Competitor X?”  
-  **Output**: Short comparison table or bullets (product, price, positioning), each point with a source URL from search_web results.
+### Examples
 
-- **Input**: “What are the main features of Product Y?”  
-  **Output**: Numbered or bullet list of features with links; note if info is from marketing vs. third-party review.
+- **”How does our pricing compare to Competitor X?”** → Comparison table (product, price, positioning) with source URLs per row.
+- **”What are the main features of Product Y?”** → Bullet list of features with links; note source type for each.
 
-## Common edge cases
+### Edge Cases
 
-- **No recent results**: Say that recent public info is scarce and suggest checking the competitor’s site or a specific source.
-- **Conflicting sources**: Present the main views and label them (e.g. “Source A says X; Source B says Y”).
-- **Vague request**: Ask one clarifying question (e.g. “Which competitors or which product line?”) then run search.
-- **Paywalled or restricted content**: Rely only on what the tool returned; do not invent content behind paywalls.
-
-## Tool usage for specific purposes
-
-- **search_web**: Use for all competitor/market lookups. Use specific queries (company + topic) rather than a single broad query. Call multiple times when comparing several competitors or dimensions.
+- **No recent results**: State that public info is limited; suggest checking the competitor’s site directly.
+- **Vague request**: Ask one clarifying question (which competitors? which product line?) before searching.
+- **Paywalled content**: Use only what the tool returned; do not fabricate content behind paywalls.

--- a/apps/backend/src/skills/document-faq-assistant/SKILL.md
+++ b/apps/backend/src/skills/document-faq-assistant/SKILL.md
@@ -1,46 +1,43 @@
 ---
 id: document-faq-assistant
-name: Document FAQ Assistant
-description: Answer from docs, cite sources
+name: document-faq-assistant
+description: “Use when answering questions from workspace documents, citing sources and quoting relevant snippets”
 role: support
 requiredTools:
   - type: builtin
     tool: search_documents
+triggers:
+  - document question
+  - knowledge base lookup
+  - FAQ answer
+  - find in docs
 ---
 
 ## Document FAQ Assistant
 
-When answering from workspace documents:
+Answer user questions by searching workspace documents. Always cite the source document and quote or paraphrase relevant snippets.
 
-- Search documents with the user’s question or key terms to find relevant snippets.
-- Cite sources: mention which document or section the answer comes from.
-- Prefer quoting or paraphrasing the doc rather than inventing; if nothing is found, say so.
-- Use a focused query (e.g. “refund policy”, “API rate limits”) for better matches.
-- When multiple snippets apply, summarize and list the most relevant ones first.
+### Workflow
 
-## Step-by-step instructions
+1. Extract key terms from the user’s question — use concise phrases, not the full sentence.
+2. Call **search_documents** with those terms (e.g., `”refund policy”`, `”API rate limits”`).
+3. Pick the most relevant snippets and base the answer on them. Cite document name and section.
+4. If the first query returns nothing, try a second query with alternative terms.
+5. Never fabricate facts. Only state what the document snippets support.
 
-1. Turn the user’s question into a short search query (key terms, not full sentence).
-2. Call **search_documents** with that query.
-3. If snippets are returned, pick the most relevant and base your answer on them; cite document and section.
-4. If nothing relevant is returned, say “I didn’t find anything in the docs about that” and suggest rephrasing or another topic.
-5. Do not make up facts; only state what the snippets support.
+### Guidelines
 
-## Examples of inputs and outputs
+- Quote or paraphrase the document rather than inventing answers.
+- When multiple snippets apply, summarize the top 1–3 and reference additional docs.
+- Answer only from documents unless the user explicitly requests general knowledge.
 
-- **Input**: “What’s the refund policy?”  
-  **Output**: Answer in 1–3 sentences quoting or paraphrasing the doc, e.g. “According to [Document name], …” with the relevant snippet content.
+### Examples
 
-- **Input**: “API rate limits?”  
-  **Output**: List limits (numbers, windows) with document reference; if docs say “contact support” for exceptions, say that.
+- **”What’s the refund policy?”** → 1–3 sentence answer quoting the doc: “According to [Document name], refunds are processed within 14 days...”
+- **”API rate limits?”** → List of limits (numbers, windows) with document reference.
 
-## Common edge cases
+### Edge Cases
 
-- **Zero results**: Tell the user no matching content was found; suggest alternative phrasings or that the topic might not be in the knowledge base.
-- **Many snippets**: Summarize the most relevant 1–3 and mention “see [doc] for more” if others matter.
-- **Conflicting info across docs**: Mention both and note which doc is more recent or authoritative if visible.
-- **User asks for something not in docs**: Answer only from docs; do not use general knowledge to fill gaps unless the user explicitly asks.
-
-## Tool usage for specific purposes
-
-- **search_documents**: Use for every FAQ-style question. One focused query is usually enough; use a second query with different terms if the first returns nothing or the question has two distinct parts.
+- **Zero results**: Tell the user nothing was found; suggest rephrasing or note the topic may not be in the knowledge base.
+- **Conflicting docs**: Present both and note which is more recent or authoritative.
+- **Many snippets**: Summarize the most relevant and mention “see [doc] for more details.”

--- a/apps/backend/src/skills/email-follow-up/SKILL.md
+++ b/apps/backend/src/skills/email-follow-up/SKILL.md
@@ -1,45 +1,44 @@
 ---
 id: email-follow-up
-name: Email Follow-up
-description: Professional follow-ups, templates
+name: email-follow-up
+description: “Use when drafting or sending professional follow-up emails after meetings, demos, or sales conversations”
 role: sales
 requiredTools:
   - type: builtin
     tool: send_email
+triggers:
+  - follow-up email
+  - send follow-up
+  - email after meeting
+  - draft email
 ---
 
 ## Email Follow-up
 
-When sending follow-up emails:
+Draft and send professional follow-up emails. Always confirm recipient and content with the user before sending.
 
-- Use a clear subject line and professional tone.
-- Keep the body concise: purpose, key points, and call to action.
-- Match the level of formality to the relationship (e.g. prospect vs. existing customer).
-- Do not include sensitive data (passwords, tokens) in the body.
-- Confirm recipient address and intent before sending.
+### Workflow
 
-## Step-by-step instructions
+1. Confirm with the user: recipient address, purpose, key points, and call to action.
+2. Draft a concise subject line (e.g., `”Following up: [topic]”`) and body — greeting, purpose, 1–3 key points, CTA, sign-off.
+3. Match formality to the relationship (prospect vs. existing customer).
+4. Never include passwords, API keys, or sensitive data in the email body.
+5. Call **send_email** only after the user explicitly confirms or requests sending.
 
-1. Confirm with the user: recipient address, purpose of the follow-up, and any key points or call to action.
-2. Draft a short subject line (e.g. “Following up: [topic]”) and body (greeting, purpose, 1–3 bullets or short paragraph, CTA, sign-off).
-3. Do not include passwords, API keys, or other secrets in the body.
-4. Call **send_email** with the agreed recipient, subject, and body only after the user has confirmed or clearly requested sending.
+### Guidelines
 
-## Examples of inputs and outputs
+- Always propose the draft first; do not send without confirmation.
+- Keep the body concise — purpose, key points, and one clear call to action.
+- If the user says “draft” rather than “send,” return the text without calling the tool.
 
-- **Input**: “Send a follow-up to john@example.com about the demo we discussed.”  
-  **Output**: Propose subject and 2–3 sentence body; ask user to confirm before sending; then call send_email once confirmed.
+### Examples
 
-- **Input**: “Draft a follow-up after a meeting with Acme.”  
-  **Output**: Return the draft only (no send) unless the user explicitly asks to send it.
+- **”Send a follow-up to john@example.com about the demo”** → Propose subject and 2–3 sentence body; ask user to confirm; call **send_email** once approved.
+- **”Draft a follow-up after a meeting with Acme”** → Return the draft only (no send) unless explicitly requested.
 
-## Common edge cases
+### Edge Cases
 
-- **Missing recipient**: Ask for the email address before drafting or sending.
-- **User says “send” without prior context**: Confirm recipient and purpose before sending.
-- **Sensitive content in user’s request**: Do not put passwords, tokens, or PII in the email; remind the user and offer a redacted version.
-- **Multiple recipients**: If the tool supports a single recipient, send to one and say you can repeat for others, or ask which one to use.
-
-## Tool usage for specific purposes
-
-- **send_email**: Use only for actually sending the follow-up after the user has confirmed recipient and content. Use it with a clear subject and plain-text or HTML body; never include secrets in the body.
+- **Missing recipient**: Ask for the email address before drafting.
+- **”Send” without context**: Confirm recipient and purpose first.
+- **Sensitive content**: Refuse to include passwords or PII; offer a redacted version.
+- **Multiple recipients**: Send to one at a time; ask which to use first.

--- a/apps/backend/src/skills/image-generation-assistant/SKILL.md
+++ b/apps/backend/src/skills/image-generation-assistant/SKILL.md
@@ -1,46 +1,44 @@
 ---
 id: image-generation-assistant
-name: Image Generation Assistant
-description: Generate images from prompts; style and composition guidance
+name: image-generation-assistant
+description: "Use when generating images from text prompts, with style and composition guidance for best results"
 role: marketing
 requiredTools:
   - type: builtin
     tool: image_generation
+triggers:
+  - generate image
+  - create image
+  - make a picture
+  - hero image
+  - illustration
 ---
 
 ## Image Generation Assistant
 
-When generating images (the actual tool is **generate_image**):
+Generate images from text prompts using the **generate_image** tool. Guide prompt construction for style, subject, and composition.
 
-- Craft detailed prompts that specify style, subject, and composition for best results.
-- Avoid sensitive or prohibited content (violence, adult content, trademarked characters, real people without consent); follow content policy.
-- Iterate on feedback: if the result is off, suggest a revised prompt (e.g. more specific style, different composition).
-- Return the public image URL from the tool so the user can view or download the image.
-- Do not invent capabilities; only use the **generate_image** tool as provided (single prompt, returns URL).
+### Workflow
 
-## Step-by-step instructions
+1. Clarify the user's intent: subject, style (photorealistic, illustration, minimalist), and constraints (colors, mood, aspect ratio).
+2. Build a detailed prompt: subject + style + composition (e.g., "centered," "wide shot") + optional details (lighting, colors).
+3. Call **generate_image** with a single prompt string. Do not pass multiple prompts or unsupported parameters.
+4. Return the public image URL. If the user requests changes, revise the prompt and generate again.
+5. If the tool returns a content policy error, explain why and suggest a safer prompt.
 
-1. Clarify the user's intent: subject, style (e.g. photorealistic, illustration, minimalist), and any constraints (colors, mood, aspect).
-2. Build a clear prompt: include subject, style, composition (e.g. "centered", "wide shot"), and optional details (lighting, colors).
-3. Call **generate_image** with the prompt string; do not pass multiple prompts or unsupported parameters.
-4. Return the image URL to the user; if they ask for changes, suggest a revised prompt and generate again.
-5. If the tool returns an error (e.g. content policy), explain and suggest a safer prompt.
+### Guidelines
 
-## Examples of inputs and outputs
+- Avoid prohibited content: violence, adult content, trademarked characters, real people without consent.
+- Iterate on feedback — add specifics like "bright lighting" or "minimal background" to refine results.
+- Generate one image at a time with a distinct prompt per image.
 
-- **Input**: "Generate a hero image for a fintech app: modern, blue and white, abstract shapes."  
-  **Output**: A prompt like "Modern hero image for fintech app, blue and white color scheme, abstract geometric shapes, clean minimalist composition, professional"; then the returned image URL.
+### Examples
 
-- **Input**: "The last image was too dark."  
-  **Output**: Revise the prompt to add "bright lighting" or "light background"; call **generate_image** again and return the new URL.
+- **"Generate a hero image for a fintech app: modern, blue and white, abstract shapes"** → Prompt: `"Modern hero image for fintech app, blue and white color scheme, abstract geometric shapes, clean minimalist composition, professional"` → Return image URL.
+- **"The last image was too dark"** → Revise prompt to include "bright lighting, light background" → Call **generate_image** again → Return new URL.
 
-## Common edge cases
+### Edge Cases
 
-- **Vague prompt**: Ask for style or subject details before generating, or propose a concrete prompt and confirm.
-- **Content policy / blocked**: Tell the user the request was rejected and suggest removing or changing sensitive elements (e.g. no real people, no trademarked content).
-- **User wants multiple images**: Generate one at a time; use the tool once per image with a distinct prompt.
-- **Tool error**: Report the error (e.g. timeout, rate limit) and suggest retrying or simplifying the prompt.
-
-## Tool usage for specific purposes
-
-- **generate_image** (builtin **image_generation**): Use with a single, detailed prompt string. Specify style, subject, composition; avoid prohibited content. Returns a public image URL.
+- **Vague prompt**: Ask for style or subject details, or propose a concrete prompt for confirmation.
+- **Content policy block**: Explain the rejection and suggest removing sensitive elements.
+- **Tool error (timeout, rate limit)**: Report the error and suggest retrying or simplifying the prompt.

--- a/apps/backend/src/skills/web-research-assistant/SKILL.md
+++ b/apps/backend/src/skills/web-research-assistant/SKILL.md
@@ -1,48 +1,45 @@
 ---
 id: web-research-assistant
-name: Web Research Assistant
-description: Find current info, cite URLs
+name: web-research-assistant
+description: “Use when researching current information on the web, finding articles, and citing URLs for facts or recommendations”
 role: product
 requiredTools:
   - type: builtin
     tool: search_web
+triggers:
+  - web research
+  - search the web
+  - find information online
+  - look up current
 ---
 
 ## Web Research Assistant
 
-When researching on the web:
+Research topics on the web and deliver concise, cited summaries. Prefer recent, authoritative sources.
 
-- Use web search to find current information; prefer recent or authoritative sources.
-- Cite URLs or sources when giving facts or recommendations.
-- Summarize findings clearly; distinguish between verified facts and inference.
-- If results are unclear or conflicting, say so and outline the main views.
-- Prefer concise answers with key links over long copy-paste.
-- If **fetch_web** is available, use it to read full articles when snippets from search are insufficient for the answer.
-
-## Step-by-step instructions
+### Workflow
 
 1. Turn the user’s question into 1–2 focused search queries.
-2. Call **search_web** with the first query; if the topic is broad, run a second query with different terms.
-3. Read the returned snippets/URLs and pick the most relevant and recent.
-4. Write a short summary with each claim tied to a source (URL or site name).
-5. If the user asked for a list or comparison, structure the answer (bullets or numbered) and cite per item.
-6. If results are conflicting or thin, say so and summarize what you found.
+2. Call **search_web** with the first query; run a second with different terms if the topic is broad.
+3. Pick the most relevant and recent results from returned snippets.
+4. If **fetch_url** is available, use it to read full articles when snippets are insufficient.
+5. Write a concise summary with each claim tied to a source URL.
+6. Structure comparisons or lists with citations per item.
 
-## Examples of inputs and outputs
+### Guidelines
 
-- **Input**: “What’s the latest on Project X release date?”  
-  **Output**: 1–2 sentences with the best available date and source URL; if unclear, “Sources suggest … but not confirmed.”
+- Distinguish verified facts from inference. When sources conflict, present all views with citations.
+- Prefer concise answers with key links over long copy-paste.
+- Use specific queries (topic + year, “how to,” or “comparison”) for better results.
 
-- **Input**: “Compare options for doing Y.”  
-  **Output**: Short comparison (e.g. table or bullets) with pros/cons and a link or citation per option.
+### Examples
 
-## Common edge cases
+- **”What’s the latest on Project X release date?”** → 1–2 sentences with the best available date and source URL; note if unconfirmed.
+- **”Compare options for doing Y”** → Comparison table or bullets with pros/cons and a citation per option.
 
-- **No good results**: Say that current public info is limited and suggest a more specific query or source.
-- **Conflicting info**: Present the main views and cite each; do not pick one without saying others exist.
-- **User asks for “everything about X”**: Give a structured summary (overview, key facts, sources) and offer to go deeper on one aspect.
-- **Paywalled or snippet-only content**: Base the answer only on what the tool returned; do not invent content.
+### Edge Cases
 
-## Tool usage for specific purposes
-
-- **search_web**: Use for all research questions. Use specific queries (topic + year or “how to” / “comparison”) for better results. Call multiple times when the question has several sub-topics or when the first query returns little.
+- **No good results**: State that public info is limited; suggest a more specific query.
+- **Conflicting info**: Present the main views and cite each source.
+- **Broad request (“everything about X”)**: Give a structured overview and offer to go deeper on one aspect.
+- **Paywalled content**: Use only what the tool returned; do not fabricate content.


### PR DESCRIPTION
Hey @pgte 👋

I ran your skills through `tessl skill review` at work and found some targeted improvements. Here's the full before/after:

| Skill | Before | After | Change |
|-------|--------|-------|--------|
| competitive-intel | 17% | 75% | +58% |
| document-faq-assistant | 17% | 73% | +56% |
| email-follow-up | 17% | 82% | +65% |
| web-research-assistant | 17% | 73% | +56% |
| image-generation-assistant | 17% | 73% | +56% |

This PR covers 5 of your 30 skill(s) in the repo. All 30 skills were scoring 17% due to the `name` field using Title Case instead of the required kebab-case format, which blocked the LLM judge from running entirely. I've capped this PR at 5 skills to keep the review manageable — the included GitHub Action covers ongoing review for the rest on future PRs.

<details>
<summary>What changed in competitive-intel</summary>

- **Fixed `name` field** from "Competitive Intelligence" to kebab-case `competitive-intel` (unblocks LLM judge)
- **Description rewritten** with "Use when..." clause and natural trigger terms (competitor analysis, market research, pricing comparison)
- **Added `triggers` array** for frontmatter compliance
- **Restructured content** into clear Workflow/Guidelines/Examples/Edge Cases sections
- All helpmaton-specific frontmatter (`id`, `role`, `requiredTools`) preserved

</details>

<details>
<summary>What changed in document-faq-assistant</summary>

- **Fixed `name` field** from "Document FAQ Assistant" to kebab-case `document-faq-assistant`
- **Description rewritten** with "Use when..." clause and trigger terms (document question, knowledge base lookup, FAQ answer)
- **Added `triggers` array** for frontmatter compliance
- **Restructured content** with clearer workflow steps and concise edge case handling

</details>

<details>
<summary>What changed in email-follow-up</summary>

- **Fixed `name` field** from "Email Follow-up" to kebab-case `email-follow-up`
- **Description rewritten** with "Use when..." clause and trigger terms (follow-up email, send follow-up, email after meeting)
- **Added `triggers` array** for frontmatter compliance
- **Restructured content** emphasizing the confirmation-before-send safety pattern

</details>

<details>
<summary>What changed in web-research-assistant</summary>

- **Fixed `name` field** from "Web Research Assistant" to kebab-case `web-research-assistant`
- **Description rewritten** with "Use when..." clause and trigger terms (web research, search the web, find information online)
- **Added `triggers` array** for frontmatter compliance
- **Restructured content** with clearer workflow and source attribution guidelines

</details>

<details>
<summary>What changed in image-generation-assistant</summary>

- **Fixed `name` field** from "Image Generation Assistant" to kebab-case `image-generation-assistant`
- **Description rewritten** with "Use when..." clause and trigger terms (generate image, create image, hero image, illustration)
- **Added `triggers` array** for frontmatter compliance
- **Restructured content** with prompt construction workflow and content policy guidance

</details>

## Tessl Skill Review GitHub Action ✅

I've also included a GitHub Action (`.github/workflows/skill-review.yml`) that automatically reviews any `SKILL.md` changed in future PRs and posts scores as a PR comment.

**What this gives you:**
- 🔍 Automatic `tessl skill review` runs on every PR touching `SKILL.md`
- 💬 One updated PR comment with scores and improvement feedback
- 🔓 **Zero extra accounts** — contributors don't need a Tessl login; only `GITHUB_TOKEN` is used
- ✅ **Non-blocking by default** — feedback-only, no surprise red CI (add `fail-threshold: 70` later if you want a hard gate)
- 📈 Covers future skills incrementally as contributors edit them

This workflow does not replace your existing CI/CD pipeline — it only reviews skill markdown on PRs.

## Want automatic AI optimization on every SKILL.md change? 🚀

The action I've added gives you **review scores** on PRs. We also have a more powerful variant — [`tesslio/skill-review-and-optimize`](https://github.com/tesslio/skill-review-and-optimize) — that can:

- Run **AI-powered optimization suggestions** on every `SKILL.md` PR (requires adding `TESSL_API_TOKEN` as a repo secret)
- Let contributors accept suggested improvements by commenting **`/apply-optimize`**
- Still works in review-only mode with zero secrets

Interested? Tick the box and I'll raise a follow-up PR:

- [ ] **Yes please!** Add the `tesslio/skill-review-and-optimize` action so every SKILL.md PR gets AI optimization suggestions + the `/apply-optimize` flow
- [ ] **No thanks** — the review scores action is enough for now

---

Honest disclosure — I work at @tesslio where we build tooling around skills like these. Not a pitch — just saw room for improvement and wanted to contribute.

Want to self-improve your skills? Just point your agent (Claude Code, Codex, etc.) at [this Tessl guide](https://docs.tessl.io/evaluate/optimize-a-skill-using-best-practices) and ask it to optimize your skill. Ping me — [@rohan-tessl](https://github.com/rohan-tessl) — if you hit any snags.

Thanks in advance 🙏
